### PR TITLE
Classifiers in aether/mvn URLs are ignored

### DIFF
--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/aether/internal/AetherBasedResolver.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/aether/internal/AetherBasedResolver.java
@@ -1,1 +1,147 @@
-/* * Copyright (C) 2010 Okidokiteam * * Licensed under the Apache License, Version 2.0 (the "License"); * you may not use this file except in compliance with the License. * You may obtain a copy of the License at * *      http://www.apache.org/licenses/LICENSE-2.0 * * Unless required by applicable law or agreed to in writing, software * distributed under the License is distributed on an "AS IS" BASIS, * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. * See the License for the specific language governing permissions and * limitations under the License. */package org.ops4j.pax.url.aether.internal;import org.apache.commons.logging.Log;import org.apache.commons.logging.LogFactory;import org.apache.maven.repository.internal.DefaultServiceLocator;import org.apache.maven.repository.internal.MavenRepositorySystemSession;import org.sonatype.aether.RepositorySystem;import org.sonatype.aether.RepositorySystemSession;import org.sonatype.aether.collection.CollectRequest;import org.sonatype.aether.collection.DependencyCollectionException;import org.sonatype.aether.connector.wagon.WagonProvider;import org.sonatype.aether.connector.wagon.WagonRepositoryConnectorFactory;import org.sonatype.aether.graph.Dependency;import org.sonatype.aether.graph.DependencyNode;import org.sonatype.aether.repository.LocalRepository;import org.sonatype.aether.repository.RemoteRepository;import org.sonatype.aether.resolution.ArtifactRequest;import org.sonatype.aether.resolution.ArtifactResolutionException;import org.sonatype.aether.resolution.DependencyRequest;import org.sonatype.aether.resolution.DependencyResolutionException;import org.sonatype.aether.spi.connector.RepositoryConnectorFactory;import org.sonatype.aether.spi.log.Logger;import org.sonatype.aether.util.artifact.DefaultArtifact;import java.io.File;import java.io.FileInputStream;import java.io.FileNotFoundException;import java.io.IOException;import java.io.InputStream;import java.util.ArrayList;import java.util.List;/** * Aether based, drop in replacement for mvn protocol */public class AetherBasedResolver {    private static final Log LOG = LogFactory.getLog( AetherBasedResolver.class );    private static final String LATEST_VERSION_RANGE = "(0.0,]";    final private String m_localRepo;    final private RepositorySystem m_repoSystem;    final private List<RemoteRepository> m_remoteRepos;    public AetherBasedResolver( String local, String[] repos )    {        m_localRepo = local;        m_repoSystem = newRepositorySystem();        m_remoteRepos = new ArrayList<RemoteRepository>();        int i = 0;        for( String r : repos ) {            RemoteRepository central = new RemoteRepository( "repos" + ( i++ ), "default", r );            LOG.debug( "+ " + r );            m_remoteRepos.add( central );        }    }    public InputStream resolve( String groupId, String artifactId, String extension, String version )        throws IOException    {        version = mapLatestToRange( version );        RepositorySystemSession session = newSession( m_repoSystem );        DefaultArtifact artifact = new DefaultArtifact( groupId, artifactId, extension, version );        try {            Dependency dependency = new Dependency( artifact, "provided" );            CollectRequest collectRequest = prepareResolveRequest( dependency );            DependencyNode node = m_repoSystem.collectDependencies( session, collectRequest ).getRoot();            File resolved = m_repoSystem.resolveDependencies( session, new DependencyRequest( node, null ) ).getArtifactResults().get( 0 ).getArtifact().getFile();            LOG.info( "Resolved (" + dependency.toString() + ") as " + resolved.getAbsolutePath() );            return new FileInputStream( resolved );        } catch( FileNotFoundException e ) {            throw new RuntimeException( e );        } catch( DependencyCollectionException e ) {            throw new IOException( "Cannot collect dependency: " + artifact );        } catch( DependencyResolutionException e ) {            throw new IOException( "Cannot collect dependency: " + artifact );        }    }    private CollectRequest prepareResolveRequest( Dependency dependency )    {        LOG.info( "Resolving using Aether Session: " + dependency.toString() );        CollectRequest collectRequest = new CollectRequest();        collectRequest.setRoot( dependency );        for( RemoteRepository repos : m_remoteRepos ) {            collectRequest.addRepository( repos );        }        return collectRequest;    }    private String mapLatestToRange( String version )    {        if( version != null && version.equals( "LATEST" ) ) {            version = LATEST_VERSION_RANGE;        }        return version;    }    private RepositorySystemSession newSession( RepositorySystem system )    {        MavenRepositorySystemSession session = new MavenRepositorySystemSession();        LocalRepository localRepo = new LocalRepository( m_localRepo );        session.setLocalRepositoryManager( system.newLocalRepositoryManager( localRepo ) );        return session;    }    private RepositorySystem newRepositorySystem()    {        DefaultServiceLocator locator = new DefaultServiceLocator();        locator.setServices( WagonProvider.class, new ManualWagonProvider() );        locator.addService( RepositoryConnectorFactory.class, WagonRepositoryConnectorFactory.class );        locator.setService( Logger.class, LogAdapter.class );        return locator.getService( RepositorySystem.class );    }}
+/*
+ * Copyright (C) 2010 Okidokiteam
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.url.aether.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.maven.repository.internal.DefaultServiceLocator;
+import org.apache.maven.repository.internal.MavenRepositorySystemSession;
+import org.sonatype.aether.RepositorySystem;
+import org.sonatype.aether.RepositorySystemSession;
+import org.sonatype.aether.collection.CollectRequest;
+import org.sonatype.aether.collection.DependencyCollectionException;
+import org.sonatype.aether.connector.wagon.WagonProvider;
+import org.sonatype.aether.connector.wagon.WagonRepositoryConnectorFactory;
+import org.sonatype.aether.graph.Dependency;
+import org.sonatype.aether.graph.DependencyNode;
+import org.sonatype.aether.repository.LocalRepository;
+import org.sonatype.aether.repository.RemoteRepository;
+import org.sonatype.aether.resolution.ArtifactRequest;
+import org.sonatype.aether.resolution.ArtifactResolutionException;
+import org.sonatype.aether.resolution.DependencyRequest;
+import org.sonatype.aether.resolution.DependencyResolutionException;
+import org.sonatype.aether.spi.connector.RepositoryConnectorFactory;
+import org.sonatype.aether.spi.log.Logger;
+import org.sonatype.aether.util.artifact.DefaultArtifact;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Aether based, drop in replacement for mvn protocol
+ */
+public class AetherBasedResolver {
+
+    private static final Log LOG = LogFactory.getLog( AetherBasedResolver.class );
+    private static final String LATEST_VERSION_RANGE = "(0.0,]";
+
+    final private String m_localRepo;
+    final private RepositorySystem m_repoSystem;
+    final private List<RemoteRepository> m_remoteRepos;
+
+    public AetherBasedResolver( String local, String[] repos )
+    {
+        m_localRepo = local;
+        m_repoSystem = newRepositorySystem();
+
+        m_remoteRepos = new ArrayList<RemoteRepository>();
+        int i = 0;
+        for( String r : repos ) {
+            RemoteRepository central = new RemoteRepository( "repos" + ( i++ ), "default", r );
+            LOG.debug( "+ " + r );
+            m_remoteRepos.add( central );
+        }
+    }
+
+    public InputStream resolve( String groupId, String artifactId, String extension, String version )
+        throws IOException
+    {
+        return resolve( groupId, artifactId, extension, version, "" );
+    }
+
+    public InputStream resolve( String groupId, String artifactId, String extension, String version, String classifier )
+        throws IOException
+    {
+        version = mapLatestToRange( version );
+
+        RepositorySystemSession session = newSession( m_repoSystem );
+        DefaultArtifact artifact = new DefaultArtifact( groupId, artifactId, classifier, extension, version );
+        try {
+            Dependency dependency = new Dependency( artifact, "provided" );
+            CollectRequest collectRequest = prepareResolveRequest( dependency );
+            DependencyNode node = m_repoSystem.collectDependencies( session, collectRequest ).getRoot();
+
+            File resolved = m_repoSystem.resolveDependencies( session, new DependencyRequest( node, null ) ).getArtifactResults().get( 0 ).getArtifact().getFile();
+
+            LOG.info( "Resolved (" + dependency.toString() + ") as " + resolved.getAbsolutePath() );
+            return new FileInputStream( resolved );
+        } catch( FileNotFoundException e ) {
+            throw new RuntimeException( e );
+        } catch( DependencyCollectionException e ) {
+            throw new IOException( "Cannot collect dependency: " + artifact );
+        } catch( DependencyResolutionException e ) {
+            throw new IOException( "Cannot collect dependency: " + artifact );
+        }
+    }
+
+    private CollectRequest prepareResolveRequest( Dependency dependency )
+    {
+        LOG.info( "Resolving using Aether Session: " + dependency.toString() );
+
+        CollectRequest collectRequest = new CollectRequest();
+        collectRequest.setRoot( dependency );
+
+        for( RemoteRepository repos : m_remoteRepos ) {
+            collectRequest.addRepository( repos );
+        }
+        return collectRequest;
+    }
+
+    private String mapLatestToRange( String version )
+    {
+        if( version != null && version.equals( "LATEST" ) ) {
+            version = LATEST_VERSION_RANGE;
+        }
+        return version;
+    }
+
+    private RepositorySystemSession newSession( RepositorySystem system )
+    {
+        MavenRepositorySystemSession session = new MavenRepositorySystemSession();
+
+        LocalRepository localRepo = new LocalRepository( m_localRepo );
+        session.setLocalRepositoryManager( system.newLocalRepositoryManager( localRepo ) );
+
+        return session;
+    }
+
+    private RepositorySystem newRepositorySystem()
+    {
+        DefaultServiceLocator locator = new DefaultServiceLocator();
+
+        locator.setServices( WagonProvider.class, new ManualWagonProvider() );
+        locator.addService( RepositoryConnectorFactory.class, WagonRepositoryConnectorFactory.class );
+        locator.setService( Logger.class, LogAdapter.class );
+
+        return locator.getService( RepositorySystem.class );
+    }
+}
+

--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/aether/internal/Connection.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/aether/internal/Connection.java
@@ -142,7 +142,7 @@ public class Connection
 
         LOG.debug( "Resolving [" + url.toExternalForm() + "]" );
 
-        return m_aetherBasedResolver.resolve( m_parser.getGroup(), m_parser.getArtifact(), m_parser.getType(), m_parser.getVersion() );
+        return m_aetherBasedResolver.resolve( m_parser.getGroup(), m_parser.getArtifact(), m_parser.getType(), m_parser.getVersion(), m_parser.getClassifier() );
     }
 
 

--- a/pax-url-aether/src/test/java/org/ops4j/pax/url/aether/AetherTest.java
+++ b/pax-url-aether/src/test/java/org/ops4j/pax/url/aether/AetherTest.java
@@ -1,1 +1,84 @@
-/* * Copyright (C) 2010 Okidokiteam * * Licensed under the Apache License, Version 2.0 (the "License"); * you may not use this file except in compliance with the License. * You may obtain a copy of the License at * *      http://www.apache.org/licenses/LICENSE-2.0 * * Unless required by applicable law or agreed to in writing, software * distributed under the License is distributed on an "AS IS" BASIS, * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. * See the License for the specific language governing permissions and * limitations under the License. */package org.ops4j.pax.url.aether;import org.junit.Test;import org.ops4j.pax.url.aether.internal.AetherBasedResolver;import org.slf4j.Logger;import org.slf4j.LoggerFactory;import org.sonatype.aether.collection.DependencyCollectionException;import org.sonatype.aether.resolution.ArtifactResolutionException;import java.io.File;import java.io.IOException;/** * Simply playing with aether api. */public class AetherTest {    private static Logger LOG = LoggerFactory.getLogger( AetherTest.class );    @Test    public void resolveArtifact()        throws DependencyCollectionException, ArtifactResolutionException, IOException    {        String[] repos = "http://repo1.maven.org/maven2/,http://scm.ops4j.org/repos/ops4j/projects/pax/runner-repository/,".split( "," );        AetherBasedResolver aetherBasedResolver = new AetherBasedResolver( getCache(), repos );        aetherBasedResolver.resolve( "org.ops4j.pax.web", "pax-web-api", "jar", "0.7.2" ).close();    }    @Test    public void resolveRangeBased()        throws DependencyCollectionException, ArtifactResolutionException, IOException    {        String[] repos = "http://repo1.maven.org/maven2/,http://scm.ops4j.org/repos/ops4j/projects/pax/runner-repository/,".split( "," );        AetherBasedResolver aetherBasedResolver = new AetherBasedResolver( getCache(), repos );        aetherBasedResolver.resolve( "org.ops4j.pax.web", "pax-web-api", "jar", "LATEST" ).close();    }    @Test    public void resolveFakeRepo()        throws DependencyCollectionException, ArtifactResolutionException, IOException    {        String[] repos = "http://repo1.maven.org/maven2/,http://scm.ops4j.org/repos/ops4j/projects/pax/runner-repository/,".split( "," );        AetherBasedResolver aetherBasedResolver = new AetherBasedResolver( getCache(), repos );        aetherBasedResolver.resolve( "org.ops4j.pax.runner.profiles", "ds", "composite", "LATEST" ).close();    }    private String getCache()        throws IOException    {        File base = new File( "target" );        base.mkdir();        File f = File.createTempFile( "aethertest", ".dir", base );        f.delete();        f.mkdirs();        LOG.info( "Caching" + " to " + f.getAbsolutePath() );        return f.getAbsolutePath();    }}
+/*
+ * Copyright (C) 2010 Okidokiteam
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.url.aether;
+
+import org.junit.Test;
+import org.ops4j.pax.url.aether.internal.AetherBasedResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonatype.aether.collection.DependencyCollectionException;
+import org.sonatype.aether.resolution.ArtifactResolutionException;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Simply playing with aether api.
+ */
+public class AetherTest {
+
+    private static Logger LOG = LoggerFactory.getLogger( AetherTest.class );
+
+    @Test
+    public void resolveArtifact()
+        throws DependencyCollectionException, ArtifactResolutionException, IOException
+    {
+        String[] repos = "http://repo1.maven.org/maven2/,http://scm.ops4j.org/repos/ops4j/projects/pax/runner-repository/,".split( "," );
+        AetherBasedResolver aetherBasedResolver = new AetherBasedResolver( getCache(), repos );
+        aetherBasedResolver.resolve( "org.ops4j.pax.web", "pax-web-api", "jar", "0.7.2" ).close();
+    }
+
+    @Test
+    public void resolveArtifactWithClassifier()
+        throws DependencyCollectionException, ArtifactResolutionException, IOException
+    {
+        String[] repos = "http://repo1.maven.org/maven2/,http://scm.ops4j.org/repos/ops4j/projects/pax/runner-repository/,".split( "," );
+        AetherBasedResolver aetherBasedResolver = new AetherBasedResolver( getCache(), repos );
+        aetherBasedResolver.resolve( "org.ops4j.pax.web", "features", "xml", "1.0.1", "features" ).close();
+    }
+
+    @Test
+    public void resolveRangeBased()
+        throws DependencyCollectionException, ArtifactResolutionException, IOException
+    {
+        String[] repos = "http://repo1.maven.org/maven2/,http://scm.ops4j.org/repos/ops4j/projects/pax/runner-repository/,".split( "," );
+        AetherBasedResolver aetherBasedResolver = new AetherBasedResolver( getCache(), repos );
+        aetherBasedResolver.resolve( "org.ops4j.pax.web", "pax-web-api", "jar", "LATEST" ).close();
+    }
+
+    @Test
+    public void resolveFakeRepo()
+        throws DependencyCollectionException, ArtifactResolutionException, IOException
+    {
+        String[] repos = "http://repo1.maven.org/maven2/,http://scm.ops4j.org/repos/ops4j/projects/pax/runner-repository/,".split( "," );
+        AetherBasedResolver aetherBasedResolver = new AetherBasedResolver( getCache(), repos );
+        aetherBasedResolver.resolve( "org.ops4j.pax.runner.profiles", "ds", "composite", "LATEST" ).close();
+    }
+
+    private String getCache()
+        throws IOException
+    {
+        File base = new File( "target" );
+        base.mkdir();
+        File f = File.createTempFile( "aethertest", ".dir", base );
+        f.delete();
+        f.mkdirs();
+        LOG.info( "Caching" + " to " + f.getAbsolutePath() );
+        return f.getAbsolutePath();
+    }
+}
+
+

--- a/pax-url-aether/src/test/java/org/ops4j/pax/url/aether/internal/ConnectionTest.java
+++ b/pax-url-aether/src/test/java/org/ops4j/pax/url/aether/internal/ConnectionTest.java
@@ -1,0 +1,52 @@
+package org.ops4j.pax.url.aether.internal;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Test;
+import org.ops4j.pax.url.maven.commons.MavenConfiguration;
+import org.ops4j.pax.url.maven.commons.MavenRepositoryURL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonatype.aether.collection.DependencyCollectionException;
+import org.sonatype.aether.resolution.ArtifactResolutionException;
+
+public class ConnectionTest
+{
+    private static Logger LOG = LoggerFactory.getLogger(ConnectionTest.class);
+
+    @Test
+    public void resolveArtifactWithClassifier()
+            throws DependencyCollectionException, ArtifactResolutionException, IOException
+    {
+        MavenConfiguration config = EasyMock.createMock(MavenConfiguration.class);
+        EasyMock.expect(config.getRepositories()).andReturn(new ArrayList<MavenRepositoryURL>()
+        {{
+                add(new MavenRepositoryURL("http://repo1.maven.org/maven2/"));
+            }});
+        EasyMock.expect(config.getLocalRepository()).andReturn(new MavenRepositoryURL("file:" + getCache()));
+        EasyMock.replay(config);
+
+        System.setProperty( "java.protocol.handler.pkgs", "org.ops4j.pax.url" );
+        Connection connection = new Connection(new URL("aether:org.ops4j.pax.web/features/1.0.1/xml/features"), config);
+        InputStream is = connection.getInputStream();
+        Assert.assertNotNull(is);
+    }
+
+    private String getCache()
+            throws IOException
+    {
+        File base = new File("target");
+        base.mkdir();
+        File f = File.createTempFile("aethertest", ".dir", base);
+        f.delete();
+        f.mkdirs();
+        LOG.info("Caching" + " to " + f.getAbsolutePath());
+        return f.getAbsolutePath();
+    }
+}


### PR DESCRIPTION
Though parsed properly, the classifiers were not being passed through to the resolver.  This commit fixes that, and adds test coverage.
