### PR TITLE
Webbundle overwrites current bundle export and import headers

### DIFF
--- a/pax-url-war/src/main/java/org/ops4j/pax/url/war/internal/WebBundleConnection.java
+++ b/pax-url-war/src/main/java/org/ops4j/pax/url/war/internal/WebBundleConnection.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 
+import aQute.lib.osgi.Analyzer;
 import org.ops4j.pax.swissbox.bnd.BndUtils;
 import org.ops4j.pax.swissbox.bnd.OverwriteMode;
 import org.osgi.framework.Constants;
@@ -81,6 +82,9 @@ public class WebBundleConnection extends WarConnection {
             {
                 throw new MalformedURLException("The webbundle URL handler can not be used with bundles");
             }
+
+            instructions.remove(Analyzer.IMPORT_PACKAGE);
+            instructions.remove(Analyzer.EXPORT_PACKAGE);
         }
         
         //OSGi-Spec 128.3.1 WAB Definition


### PR DESCRIPTION
Due to merge of manifests for handling Web-ContextPath, the current bundle's Import-Package and Exprot-Package headers are being modified which can create problems
