### PR TITLE
prevent NPE in AetherBasedResolver.addServer

### DIFF
--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java
@@ -421,7 +421,8 @@ public class AetherBasedResolver {
         }
         
         for (Server server : m_settings.getServers()) {
-            if (server.getConfiguration() != null) {
+            if (server.getConfiguration() != null
+                && server.getConfiguration().getChild("httpHeaders") != null) {
                 addServerConfig(session, server);
             }
         }


### PR DESCRIPTION
Suggesting a fix for an issue we faced in HK2 project.
If the settings.xml contains a server entry with a configuration element but without httpHeaders, it raises a NPE.

Didn't create an issue on JIRA cause I can't create an account.
