### PR TITLE
added a only local repo resolution using a specific uri handler called...

### DIFF
--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/ServiceConstants.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/ServiceConstants.java
@@ -39,6 +39,11 @@ public interface ServiceConstants
     String PROTOCOL = "mvn";
 
     /**
+     * The protocol name used to only resolve on local repositories.
+     */
+    String LOCAL_REPO_PROTOCOL = "localrepositories";
+
+    /**
      * Warning: use only in framework properties.  If present, do not accept configuration, wait for one without this flag.
      */
     String REQUIRE_CONFIG_ADMIN_CONFIG = "requireConfigAdminConfig";

--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/ServiceConstants.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/ServiceConstants.java
@@ -41,7 +41,7 @@ public interface ServiceConstants
     /**
      * The protocol name used to only resolve on local repositories.
      */
-    String LOCAL_REPO_PROTOCOL = "localrepositories";
+    String LOCAL_REPO_PROTOCOL = "local";
 
     /**
      * Warning: use only in framework properties.  If present, do not accept configuration, wait for one without this flag.

--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/Activator.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/Activator.java
@@ -61,6 +61,12 @@ public class Activator extends AbstractURLStreamHandlerService
      * Handler service registration. Used for cleanup.
      */
     private ServiceRegistration<URLStreamHandlerService> m_handlerReg;
+
+    /**
+     * Handler service registration. Used for cleanup.
+     */
+    private ServiceRegistration<URLStreamHandlerService> m_handlerLocalRepoReg;
+
     /**
      * Managed service registration. Used for cleanup.
      */
@@ -108,6 +114,11 @@ public class Activator extends AbstractURLStreamHandlerService
             m_handlerReg.unregister();
             m_handlerReg = null;
         }
+        if ( m_handlerLocalRepoReg != null )
+        {
+            m_handlerLocalRepoReg.unregister();
+            m_handlerLocalRepoReg = null;
+        }
         if ( m_managedServiceReg != null )
         {
             m_managedServiceReg.unregister();
@@ -142,6 +153,18 @@ public class Activator extends AbstractURLStreamHandlerService
                 URLStreamHandlerService.class,
                 this,
                 props);
+        //create a dummy localrepositories url handler to detect the client wants only local resolution (no internet)
+        final Dictionary<String, Object> propsLocalRepo = new Hashtable<String, Object>();
+        propsLocalRepo.put( URLConstants.URL_HANDLER_PROTOCOL, ServiceConstants.LOCAL_REPO_PROTOCOL );
+        m_handlerLocalRepoReg = safeRegisterService(
+                URLStreamHandlerService.class,
+                new AbstractURLStreamHandlerService(){
+
+                    @Override
+                    public URLConnection openConnection(URL u) throws IOException {
+                        return null;
+                    }},
+                    propsLocalRepo);
     }
 
     /**

--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java
@@ -520,11 +520,14 @@ public class AetherBasedResolver implements MavenResolver {
                          MavenRepositoryURL repositoryURL ) throws IOException {
 
         List<LocalRepository> defaultRepos = selectDefaultRepositories();
-        List<RemoteRepository> remoteRepos = selectRepositories();
-        if (repositoryURL != null) {
-            addRepo(remoteRepos, repositoryURL);
-        }
-        assignProxyAndMirrors( remoteRepos );
+        List<RemoteRepository> remoteRepos = Collections.EMPTY_LIST;
+        if (repositoryURL == null || !repositoryURL.useOnlyLocalRepositories()) {
+            remoteRepos = selectRepositories();
+            if (repositoryURL != null) {
+                addRepo(remoteRepos, repositoryURL);
+            }
+            assignProxyAndMirrors(remoteRepos);
+        }//else not url specified or only local onces so keep going
         File resolved = resolve( defaultRepos, remoteRepos, artifact );
 
         LOG.debug( "Resolved ({}) as {}", artifact.toString(), resolved.getAbsolutePath() );

--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/config/MavenRepositoryURL.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/config/MavenRepositoryURL.java
@@ -52,6 +52,12 @@ public class MavenRepositoryURL
      * Repository file (only if URL is a file URL).
      */
     private final File m_file;
+
+    /**
+     * only if url is of type "localrepositories"
+     */
+    private final boolean m_onlyLocalRepositories;
+
     /**
      * True if the repository contains snapshots.
      */
@@ -203,33 +209,32 @@ public class MavenRepositoryURL
         m_releasesChecksumPolicy = checksumReleases != null ? checksumReleases : checksum;
         m_snapshotsChecksumPolicy = checksumSnapshots != null ? checksumSnapshots : checksum;
 
-        if( m_repositoryURL.getProtocol().equals( "file" ) )
-        {
-            try
-            {
-                // You must transform to URI to decode the path (manage a path with a space or non
-                // us character)
-                // like D:/documents%20and%20Settings/SESA170017/.m2/repository
-                // the path can be store in path part or in scheme specific part (if is relatif
-                // path)
-                // the anti-slash character is not a valid character for uri.
-                spec = spec.replaceAll( "\\\\", "/" );
-                spec = spec.replaceAll( " ", "%20" );
-                URI uri = new URI( spec );
-                String path = uri.getPath();
-                if( path == null )
-                    path = uri.getSchemeSpecificPart();
-                m_file = new File( path );
-
-            }
-            catch ( URISyntaxException e )
-            {
-                throw new MalformedURLException( e.getMessage() );
-            }
-        }
-        else
-        {
+        if (m_repositoryURL.getProtocol().equals("file")) {
+            m_onlyLocalRepositories = false;
+                try {
+                    // You must transform to URI to decode the path (manage a path with a space or non
+                    // us character)
+                    // like D:/documents%20and%20Settings/SESA170017/.m2/repository
+                    // the path can be store in path part or in scheme specific part (if is relatif
+                    // path)
+                    // the anti-slash character is not a valid character for uri.
+                    spec = spec.replaceAll( "\\\\", "/" );
+                    spec = spec.replaceAll( " ", "%20" );
+                    URI uri = new URI( spec );
+                    String path = uri.getPath();
+                    if( path == null )
+                        path = uri.getSchemeSpecificPart();
+                    m_file = new File( path );
+    
+                } catch (URISyntaxException e) {
+                    throw new MalformedURLException(e.getMessage());
+                }
+        } else if (m_repositoryURL.getProtocol().equals(ServiceConstants.LOCAL_REPO_PROTOCOL)) {
+            m_onlyLocalRepositories = true;
             m_file = null;
+        }else {
+            m_file = null;
+            m_onlyLocalRepositories = false;
         }
     }
 
@@ -271,6 +276,14 @@ public class MavenRepositoryURL
     public File getFile()
     {
         return m_file;
+    }
+
+    /**
+     * Getter
+     * @return whether the url is only for local repositories resolution
+     */
+    public boolean useOnlyLocalRepositories() {
+        return m_onlyLocalRepositories;
     }
 
     /**

--- a/pax-url-aether/src/test/java/org/ops4j/pax/url/mvn/AetherTest.java
+++ b/pax-url-aether/src/test/java/org/ops4j/pax/url/mvn/AetherTest.java
@@ -15,6 +15,7 @@
  */
 package org.ops4j.pax.url.mvn;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -71,13 +72,14 @@ public class AetherTest {
         try{
             //check the remote artifact is not resolved and therefore throws an exception
             try{
-                aetherBasedResolver.resolve( "mvn:localrepositories://@id=foo!org.ops4j.pax.web/pax-web-api/LATEST" ); //$NON-NLS-1$
-                fail( "mvn:localrepositories://@id=foo!org.ops4j.pax.web/pax-web-api/LATEST should never be resolved" ); //$NON-NLS-1$
+                aetherBasedResolver.resolve( "mvn:"+ServiceConstants.LOCAL_REPO_PROTOCOL+"://@id=foo!org.ops4j.pax.web/pax-web-api/LATEST" ); //$NON-NLS-1$
+                fail( "mvn:"+ServiceConstants.LOCAL_REPO_PROTOCOL+"://@id=foo!org.ops4j.pax.web/pax-web-api/LATEST should never be resolved" ); //$NON-NLS-1$
             }catch(IOException ioe){
                 //expected exception
             }
             //check local artifact is resolved
             File resolvedFile = aetherBasedResolver.resolve( "mvn:file://local.repositories@id=foo!ant/ant/1.5.1" ); //$NON-NLS-1$
+            assertTrue( "File should exist", resolvedFile.exists() );
         }finally{
             aetherBasedResolver.close();
         }


### PR DESCRIPTION
localrepositories://
Hi guys.
I have improved (I hope) the pax-url-mvn resolver with a way of forcing the resolution only on local repositories and not trying to access remote ones.
For this I created a new url protocol called **localrepositories** to switch to local resolution only.
here is an example of uri 
`          mvn:localrepositories://@id=foo!org.ops4j.pax.web/pax-web-api/LATEST`
that should only succed if the artifact is present in the local repositories and will fail if not.
I hope this can make it into a future official release.