### PR TITLE
PAXSB-87 - bump swissbox to v1.8.2

### DIFF
--- a/pax-url-war/pom.xml
+++ b/pax-url-war/pom.xml
@@ -89,6 +89,10 @@
       <artifactId>pax-url-commons</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>biz.aQute.bnd</groupId>
+      <artifactId>bndlib</artifactId>
+    </dependency>
 
     <!-- Provided dependencies (not transitive) -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency.osgicore.version>4.3.1</dependency.osgicore.version>
         <dependency.osgicomp.version>4.3.1</dependency.osgicomp.version>
         <dependency.paxexam.version>3.5.0</dependency.paxexam.version>
-        <dependency.swissbox.version>1.8.1</dependency.swissbox.version>
+        <dependency.swissbox.version>1.8.2</dependency.swissbox.version>
         <dependency.slf4j.version>1.6.6</dependency.slf4j.version>
         <dependency.wagon.version>2.8</dependency.wagon.version>
         <wiki.url>http://team.ops4j.org/wiki/display/paxurl</wiki.url>


### PR DESCRIPTION
Note:
it needs also the additional Maven dependency reference, that is no longer inherited automatically from swissbox