### PR TITLE
[PAXURL-318] Fixed memory leak in AetherBasedResolver

### DIFF
--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java
@@ -778,16 +778,7 @@ public class AetherBasedResolver implements MavenResolver {
 
     private RepositorySystemSession newSession(LocalRepository repo) {
         if (repo == null) {
-            if (localRepository == null) {
-                File local;
-                if( m_config.getLocalRepository() != null ) {
-                    local = m_config.getLocalRepository().getFile();
-                } else {
-                    local = new File( System.getProperty( "user.home" ), ".m2/repository" );
-                }
-                localRepository = new LocalRepository( local );
-            }
-            repo = localRepository;
+            repo = getLocalRepository();
         }
         Deque<RepositorySystemSession> deque = sessions.get(repo);
         RepositorySystemSession session = null;
@@ -816,14 +807,7 @@ public class AetherBasedResolver implements MavenResolver {
         if( repo != null ) {
             session.setLocalRepositoryManager( m_repoSystem.newLocalRepositoryManager( session, repo ) );
         } else {
-            File local;
-            if( m_config.getLocalRepository() != null ) {
-                local = m_config.getLocalRepository().getFile();
-            } else {
-                local = new File( System.getProperty( "user.home" ), ".m2/repository" );
-            }
-            LocalRepository localRepo = new LocalRepository( local );
-            session.setLocalRepositoryManager( m_repoSystem.newLocalRepositoryManager( session, localRepo ) );
+            session.setLocalRepositoryManager( m_repoSystem.newLocalRepositoryManager( session, getLocalRepository() ) );
         }
 
         session.setMirrorSelector( m_mirrorSelector );
@@ -844,6 +828,19 @@ public class AetherBasedResolver implements MavenResolver {
         session.setOffline( m_config.isOffline() );
 
         return session;
+    }
+
+    private LocalRepository getLocalRepository() {
+      if (localRepository == null) {
+          File local;
+          if( m_config.getLocalRepository() != null ) {
+              local = m_config.getLocalRepository().getFile();
+          } else {
+              local = new File(System.getProperty( "user.home" ), ".m2/repository");
+          }
+          localRepository = new LocalRepository(local, "simple");
+      }
+      return localRepository;
     }
 
     private void addServerConfig( DefaultRepositorySystemSession session, Server server )


### PR DESCRIPTION
This fixes the memory leak https://ops4j1.jira.com/browse/PAXURL-318

The only possibility I see is that the releaseSession() method adds the session to a different deque than the newSession polls. 
both methods use the sessions.get(repo) to look up the deque. I doublechecked equals and hashcode, but in doubt we should avoid creating new LocalRepository instances over and over again. Especially when in one part of that symmetric code we reuse a cached instance, and the other one always creates a new one.

The problem however was a more subtle one:
When a session was created with (null), the code looked up the Deque for
the local repository.

However, when it was released, it was added to the Deque for the local repository
of the session. It was assumed that this would be the same, but it was a
LocalRepository with no type set in the create case and in the second case a
different LocalRepository was created by SimpleLocalRepositoryManager with the
type "simple". This caused the releaseSession method to put it to a different key,
than the createSession would use to look up.

This fix passes in "simple" as type, causing the two keys to be equal() and thus
the ConcurrentMap lookup to be successful.