### PR TITLE
Depend only on "slf4j-api"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,25 +304,10 @@
                 <version>${dependency.slf4j.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
-                <version>${dependency.slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jcl-over-slf4j</artifactId>
-                <version>${dependency.slf4j.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${dependency.logback.version}</version>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>commons-logging</groupId>
-                <artifactId>commons-logging</artifactId>
-                <version>1.1.3</version>
             </dependency>
 
             <!-- OSGi Alliance -->


### PR DESCRIPTION
I think that your depending on several logging libraries is not a good thing. IMO, a clean approach would be to depend only on "slf4j-api" (and maybe one of its implementations in scope test) 

The change I'm proposing might break the build (I haven't tested it) but I just wanted to bring the topic to the table. Low level libraries such as yours, should only rely on "slf4j-api". The choosing of the implementation should be is up to the integrator.

If possible, you should also get rid of commons-logging. 

What do you think?