### PR TITLE
Fix LATEST_VERSION_RANGE so it actually resolves the latest version

### DIFF
--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java
@@ -123,7 +123,7 @@ import org.sonatype.plexus.components.cipher.PlexusCipherException;
 public class AetherBasedResolver implements MavenResolver {
 
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger( AetherBasedResolver.class );
-    private static final String LATEST_VERSION_RANGE = "(0.0,]";
+    private static final String LATEST_VERSION_RANGE = "[0.0,)";
     private static final String REPO_TYPE = "default";
     private static final String SCHEMA_HTTP = "http";
     private static final String SCHEMA_HTTPS = "https";
@@ -1173,4 +1173,3 @@ public class AetherBasedResolver implements MavenResolver {
         return locator.getService( RepositorySystem.class );
     }
 }
-


### PR DESCRIPTION
I'm not very experienced in this testing suite, but I've seen that version ranges in general do work, except the `LATEST_VERSION_RANGE` never really gets tested. This range is faulty, as confirmed by the official maven documentation (http://maven.apache.org/enforcer/enforcer-rules/versionRanges.html) and own experience.

Now the range is set to `x >= 0.0`, instead of a range that doesn't make sense in the first place.