### PR TITLE
Upgrade Aether and wagon

### DIFF
--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/wagon/ConfigurableHttpWagon.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/wagon/ConfigurableHttpWagon.java
@@ -99,7 +99,10 @@ public class ConfigurableHttpWagon extends HttpWagon {
             requestConfigBuilder.setConnectTimeout( getTimeout() );
         }
 
-        getLocalContext().setRequestConfig(requestConfigBuilder.build());
+        HttpClientContext localContext = HttpClientContext.create();
+        localContext.setCredentialsProvider(getCredentialsProvider());
+        localContext.setAuthCache(getAuthCache());
+        localContext.setRequestConfig(requestConfigBuilder.build());
 
         if ( config != null && config.isUsePreemptive() )
         {
@@ -146,7 +149,7 @@ public class ConfigurableHttpWagon extends HttpWagon {
             }
         }
         
-        return client.execute( httpMethod, getLocalContext() );
+        return client.execute( httpMethod, localContext );
     }
 
     @Override
@@ -181,10 +184,6 @@ public class ConfigurableHttpWagon extends HttpWagon {
 
     private CredentialsProvider getCredentialsProvider() {
         return getField(CredentialsProvider.class, "credentialsProvider");
-    }
-
-    private HttpClientContext getLocalContext() {
-        return getField(HttpClientContext.class, "localContext");
     }
 
     private <T> T getField(Class<T> clazz, String name) {

--- a/pom.xml
+++ b/pom.xml
@@ -53,18 +53,18 @@
     <properties>
         <release-paxurl-altGitURL>scm:git:ssh://git@github.com/ops4j/org.ops4j.pax.url.git</release-paxurl-altGitURL>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dependency.aether.version>1.0.2.v20150114</dependency.aether.version>
+        <dependency.aether.version>1.1.0</dependency.aether.version>
         <dependency.base.version>1.5.0</dependency.base.version>
         <dependency.bndlib.version>2.3.0</dependency.bndlib.version>
         <!-- higher versions of logback import slf4j 1.7 -->
         <dependency.logback.version>1.0.7</dependency.logback.version>
-        <dependency.maven.version>3.2.1</dependency.maven.version>
+        <dependency.maven.version>3.2.5</dependency.maven.version>
         <dependency.osgicore.version>4.3.1</dependency.osgicore.version>
         <dependency.osgicomp.version>4.3.1</dependency.osgicomp.version>
         <dependency.paxexam.version>3.5.0</dependency.paxexam.version>
         <dependency.swissbox.version>1.8.2</dependency.swissbox.version>
         <dependency.slf4j.version>1.6.6</dependency.slf4j.version>
-        <dependency.wagon.version>2.8</dependency.wagon.version>
+        <dependency.wagon.version>2.12</dependency.wagon.version>
         <wiki.url>http://team.ops4j.org/wiki/display/paxurl</wiki.url>
     </properties>
 


### PR DESCRIPTION
This upgraded aether and maven to a more recent version.
change was trivial and all tests still pass.
the only change required was to adopt to
https://github.com/apache/maven-wagon/commit/1a005f1c3fe7492c10b06567738453118f1c15b6
