### PR TITLE
[PAXURL-286] settings.xml is ignored if there is a space in the path

### DIFF
--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/config/MavenConfigurationImpl.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/config/MavenConfigurationImpl.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.net.Authenticator;
 import java.net.MalformedURLException;
 import java.net.PasswordAuthentication;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -103,7 +104,7 @@ public class MavenConfigurationImpl implements MavenConfiguration {
 
         m_pid = pid == null ? "" : pid + ".";
         m_propertyResolver = propertyResolver;
-        settings = buildSettings(getLocalRepoPath(propertyResolver), getSettingsPath(),
+        settings = buildSettings(getLocalRepoPath(propertyResolver), getSettingsFileUrl(),
             useFallbackRepositories());
     }
 
@@ -605,17 +606,11 @@ public class MavenConfigurationImpl implements MavenConfiguration {
         }
     }
 
-    private String getSettingsPath() {
-        URL url = getSettingsFileUrl();
-        return url == null ? null : url.getPath();
-    }
-
     private String getLocalRepoPath(PropertyResolver props) {
         return props.get(ServiceConstants.PID + "." + ServiceConstants.PROPERTY_LOCAL_REPOSITORY);
     }
 
-    private Settings buildSettings(String localRepoPath, String settingsPath,
-        boolean useFallbackRepositories) {
+    private Settings buildSettings(String localRepoPath, URL settingsPath, boolean useFallbackRepositories) {
         Settings settings;
         if (settingsPath == null) {
             settings = new Settings();
@@ -624,7 +619,11 @@ public class MavenConfigurationImpl implements MavenConfiguration {
             DefaultSettingsBuilderFactory factory = new DefaultSettingsBuilderFactory();
             DefaultSettingsBuilder builder = factory.newInstance();
             SettingsBuildingRequest request = new DefaultSettingsBuildingRequest();
-            request.setUserSettingsFile(new File(settingsPath));
+            try {
+                request.setUserSettingsFile(new File(settingsPath.toURI()));
+            } catch (URISyntaxException e) {
+                // should never happens because it is returned by safeGetFile
+            }
             try {
                 SettingsBuildingResult result = builder.build(request);
                 settings = result.getEffectiveSettings();

--- a/pax-url-aether/src/test/java/org/ops4j/pax/url/mvn/internal/SettingsTest.java
+++ b/pax-url-aether/src/test/java/org/ops4j/pax/url/mvn/internal/SettingsTest.java
@@ -1,0 +1,44 @@
+package org.ops4j.pax.url.mvn.internal;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
+
+import java.io.File;
+import java.util.Properties;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.settings.Settings;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.ops4j.pax.url.mvn.ServiceConstants;
+import org.ops4j.pax.url.mvn.internal.config.MavenConfigurationImpl;
+import org.ops4j.util.property.PropertiesPropertyResolver;
+
+public class SettingsTest {
+    @Rule
+    public TemporaryFolder fileRule = new TemporaryFolder();
+
+    @Test
+    public void settings_xml_in_path_that_contains_spaces() throws Exception {
+        File folderWithSpaces = fileRule.newFolder("path with spaces");
+        File settingsFile = new File(folderWithSpaces, "settings.xml");
+        FileUtils.copyURLToFile(getClass().getResource("/settings/settingsWithLocalRepository.xml"), settingsFile);
+
+        // simulate safeGetFile private method where spaces are replaced with %20
+        String settingsFileURL = settingsFile.toURI().toURL().toExternalForm();
+        assumeThat(settingsFileURL, containsString("%20"));
+
+        Properties props = new Properties();
+        props.put(ServiceConstants.PID + '.' + ServiceConstants.PROPERTY_SETTINGS_FILE, settingsFileURL);
+
+        PropertiesPropertyResolver propertyResolver = new PropertiesPropertyResolver(props);
+        MavenConfigurationImpl config = new MavenConfigurationImpl(propertyResolver, ServiceConstants.PID);
+        
+        Settings settings = config.getSettings();
+        assertThat("settings.xml was not parsed because its path contains spaces",
+                "repository", equalTo(settings.getLocalRepository()));
+    }
+}


### PR DESCRIPTION
When the settins.xml file path contain spaces during conversion to URI all spaces become %20 and when converted back to File this cause to DefaultSettingsBuilder failure when get the file that returns a void Settings instance.