### PR TITLE
Update plexus utils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
-                <version>3.0.17</version>
+                <version>3.0.24</version>
             </dependency>
             <dependency>
                 <groupId>org.sonatype.plexus</groupId>


### PR DESCRIPTION
We should update plexus-utils to get rid of the following CVE:

plexus-utils-3.0.17.jar (pkg:maven/org.codehaus.plexus/plexus-utils@3.0.17, cpe:2.3:a:plexus-utils_project:plexus-utils:3.0.17:*:*:*:*:*:*:*) : Directory traversal in org.codehaus.plexus.util.Expand, Possible XML Injection

