### PR TITLE
[Fixes #455] Fix wrong LocalRepository key to prevent memory leak

### DIFF
--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java
@@ -1103,11 +1103,15 @@ public class AetherBasedResolver implements MavenResolver {
             sessions.putIfAbsent(repo, new ConcurrentLinkedDeque<RepositorySystemSession>());
             deque = sessions.get(repo);
         }
-        // we can't unset SESSION_CHECKS because it is an object and not a String
-        // therefore copy the systemSession and unset the data
-        DefaultRepositorySystemSession systemSession = new DefaultRepositorySystemSession(session);
-        systemSession.setData(null);
-        deque.add(systemSession);
+        if (session instanceof DefaultRepositorySystemSession) {
+            ((DefaultRepositorySystemSession) session).setData(null);
+        } else {
+            // we can't unset SESSION_CHECKS because it is an object and not a String
+            // therefore copy the systemSession and unset the data
+            session = new DefaultRepositorySystemSession(session).setCache(null);
+        }
+
+        deque.add(session);
     }
 
     private RepositorySystemSession createSession(LocalRepository repo) {

--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java
@@ -1103,11 +1103,11 @@ public class AetherBasedResolver implements MavenResolver {
             sessions.putIfAbsent(repo, new ConcurrentLinkedDeque<RepositorySystemSession>());
             deque = sessions.get(repo);
         }
+        // we can't unset SESSION_CHECKS because it is an object and not a String
+        // therefore copy the systemSession and unset the data
         if (session instanceof DefaultRepositorySystemSession) {
             ((DefaultRepositorySystemSession) session).setData(null);
         } else {
-            // we can't unset SESSION_CHECKS because it is an object and not a String
-            // therefore copy the systemSession and unset the data
             session = new DefaultRepositorySystemSession(session).setCache(null);
         }
 

--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java
@@ -1103,8 +1103,11 @@ public class AetherBasedResolver implements MavenResolver {
             sessions.putIfAbsent(repo, new ConcurrentLinkedDeque<RepositorySystemSession>());
             deque = sessions.get(repo);
         }
-        session.getData().set(SESSION_CHECKS, null);
-        deque.add(session);
+        // we can't unset SESSION_CHECKS because it is an object and not a String
+        // therefore copy the systemSession and unset the data
+        DefaultRepositorySystemSession systemSession = new DefaultRepositorySystemSession(session);
+        systemSession.setData(null);
+        deque.add(systemSession);
     }
 
     private RepositorySystemSession createSession(LocalRepository repo) {

--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java
@@ -1166,7 +1166,7 @@ public class AetherBasedResolver implements MavenResolver {
             } else {
                 local = new File(System.getProperty("user.home"), ".m2/repository");
             }
-            localRepository = new LocalRepository(local, "simple");
+            localRepository = new LocalRepository(local, "pax-url");
         }
         return localRepository;
     }


### PR DESCRIPTION
When a local repo is validated, it is created with type `simple`.
https://github.com/ops4j/org.ops4j.pax.url/blob/614b07ab7ae77ff9a81c2d438bc216e73ae9021d/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java#L1081
However as soon as this is then used within the `createSession`, the type is changed to `pax-url` because of the `PaxLocalRepositoryManager`.
https://github.com/ops4j/org.ops4j.pax.url/blob/614b07ab7ae77ff9a81c2d438bc216e73ae9021d/pax-url-aether-support/src/main/java/org/eclipse/aether/internal/impl/PaxLocalRepositoryManager.java#L45

Fixes #455

