### PR TITLE
Updating plexus-utils to 3.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <dependency.org.codehaus.plexus.plexus-cipher>2.0</dependency.org.codehaus.plexus.plexus-cipher>
         <dependency.org.codehaus.plexus.plexus-interpolation>1.29</dependency.org.codehaus.plexus.plexus-interpolation>
         <dependency.org.codehaus.plexus.plexus-sec-dispatcher>2.0</dependency.org.codehaus.plexus.plexus-sec-dispatcher>
-        <dependency.org.codehaus.plexus.plexus-utils>3.6.0</dependency.org.codehaus.plexus.plexus-utils>
+        <dependency.org.codehaus.plexus.plexus-utils>3.6.1</dependency.org.codehaus.plexus.plexus-utils>
         <dependency.org.easymock>5.6.0</dependency.org.easymock>
         <dependency.org.eclipse.jetty>11.0.26</dependency.org.eclipse.jetty>
         <dependency.org.ops4j.base>1.5.1</dependency.org.ops4j.base>


### PR DESCRIPTION
To fix https://nvd.nist.gov/vuln/detail/CVE-2025-67030