### PR TITLE
[PAXURL-464] Fix URISyntaxException when Maven repository path contains spaces

### DIFF
--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/config/MavenConfigurationImpl.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/config/MavenConfigurationImpl.java
@@ -246,10 +246,11 @@ public class MavenConfigurationImpl implements MavenConfiguration {
     private File safeGetFile(String option, String path, boolean directory) {
         if (path != null && !path.trim().isEmpty()) {
             path = path.trim().replace('\\', '/');
-            path = path.trim().replaceAll("%5C", "/");
-            path = path.trim().replaceAll("%5c", "/");
+            path = path.trim().replace("%5C", "/");
+            path = path.trim().replace("%5c", "/");
             if (path.startsWith("file:")) {
-                URI uri = URI.create(path);
+                // encode spaces before URI.create() - raw spaces cause IllegalArgumentException
+                URI uri = URI.create(path.replace(" ", "%20"));
                 if (uri.isOpaque()) {
                     // no slash after "file:"
                     path = uri.getSchemeSpecificPart();

--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/config/MavenRepositoryURL.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/config/MavenRepositoryURL.java
@@ -377,7 +377,10 @@ public class MavenRepositoryURL
         }
         String spec = urlBuilder.toString().trim();
         spec = spec.replaceAll("\\\\", "/");
-        spec = spec.replaceAll("%5C", "/");
+        spec = spec.replace("%5C", "/");
+        // encode spaces before creating the URI - raw spaces are illegal in URIs and would cause
+        // URI.create() to throw an IllegalArgumentException for paths like "file:/C:/Program Files/repo"
+        spec = spec.replace(" ", "%20");
         if (!spec.endsWith("/")) {
             spec += "/";
         }
@@ -455,7 +458,7 @@ public class MavenRepositoryURL
                 // path)
                 // the anti-slash character is not a valid character for uri.
                 spec = spec.replaceAll( "\\\\", "/" );
-                spec = spec.replaceAll( " ", "%20" );
+                spec = spec.replace(" ", "%20" );
                 URI uri = new URI( spec );
                 String path = uri.getPath();
                 if( path == null )


### PR DESCRIPTION
Encode raw spaces with %20 before passing the spec to URI.create() in MavenRepositoryURL and MavenConfigurationImpl#safeGetFile. Without this, paths like "file:C:/Program Files/repo" caused IllegalArgumentException because raw spaces are illegal in URIs. Patch contributed by Rico Neubauer.

This is a "backport" on the main branch.